### PR TITLE
Feature/auth

### DIFF
--- a/.github/workflows/railway-deploy.yml
+++ b/.github/workflows/railway-deploy.yml
@@ -27,18 +27,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       
-      - name: Login to Railway
-        uses: docker/login-action@v3
-        with:
-          registry: registry.railway.app
-          username: "${{ secrets.RAILWAY_TOKEN }}"
-          password: "${{ secrets.RAILWAY_TOKEN }}"
+      # - name: Login to Railway
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: registry.railway.app
+      #     username: "${{ secrets.RAILWAY_TOKEN }}"
+      #     password: "${{ secrets.RAILWAY_TOKEN }}"
       
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: registry.railway.app/${{ secrets.RAILWAY_PROJECT_ID }}/smart-attendance-api-image:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # - name: Build and push Docker image
+      #   uses: docker/build-push-action@v5
+      #   with:
+      #     context: .
+      #     push: true
+      #     tags: registry.railway.app/${{ secrets.RAILWAY_PROJECT_ID }}/smart-attendance-api-image:latest
+      #     cache-from: type=gha
+      #     cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -38,8 +38,6 @@ build/
 .DS_Store
 
 ### Environment files
-.env*
-config/env/*
 !config/env/.env-prod
 .env.dev
 

--- a/config/env/.env.dev.example
+++ b/config/env/.env.dev.example
@@ -4,7 +4,7 @@ PROD_PORT=8080
 BASE_URL=http://localhost:8080
 
 # Security Configuration
-JWT_SECRETE=your-secret-key
+JWT_SECRET=your-secret-key
 
 # Database Configuration
 DB_DRIVER_CLASS_NAME=org.postgresql.Driver

--- a/config/env/.env.dev.example
+++ b/config/env/.env.dev.example
@@ -1,0 +1,24 @@
+# Deployment Configuration
+PROD_HOST=0.0.0.0
+PROD_PORT=8080
+BASE_URL=http://localhost:8080
+
+# Security Configuration
+JWT_SECRETE=your-secret-key
+
+# Database Configuration
+DB_DRIVER_CLASS_NAME=org.postgresql.Driver
+DB_HOST=localhost
+DATABASE_PORT=5432
+DB_USERNAME=your-db-username
+DB_PASSWORD=your-db-password
+DB_NAME=your-db-name
+
+# SMTP Configuration
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USERNAME=your.email@gmail.com
+SMTP_PASSWORD=your-app-specific-password
+SMTP_FROM_EMAIL=your.email@gmail.com
+SMTP_SSL=true
+SMTP_STARTTLS=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref 
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin-version" }
 reflection = { module = "org.reflections:reflections", version.ref = "reflection"}
 jakarta-mail-api = { module = "jakarta.mail:jakarta.mail-api", version.ref = "jakarta-mail-version"}
-jakarta-mail-impl = { module = "org.eclipse.angus:jakarta.mail", version.ref = "jakarta-mail-version"}
+jakarta-mail-impl = { module = "org.eclipse.angus:angus-mail", version.ref = "jakarta-mail-version"}
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-version" }

--- a/src/main/kotlin/com/example/api/AuthApi.kt
+++ b/src/main/kotlin/com/example/api/AuthApi.kt
@@ -7,6 +7,8 @@ import com.example.model.RefreshTokenRequest
 import com.example.model.UserRegistrationRequest
 import com.example.services.auth.AuthService
 import com.example.util.ApiResponse
+import com.example.web.RequestUtils
+import com.example.web.Routes
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.jwt.JWTPrincipal
@@ -21,128 +23,130 @@ import java.lang.IllegalArgumentException
 import java.util.UUID
 
 fun Route.authRoutes(authService: AuthService) {
-    route("/auth") {
-        post ("/sign-up"){
-            try {
-                val request = call.receive<UserRegistrationRequest>()
-                val user = authService.registerUser(request)
-                call.respond(
-                    HttpStatusCode.Created,
-                    ApiResponse(success = true, message = "User registered successfully", data = user)
-                )
-            } catch (e: IllegalArgumentException) {
-                call.respond(
-                    HttpStatusCode.BadRequest,
-                    ApiResponse(success = false, message = e.message, data = null, error = e.message)
-                )
-            } catch (e: Exception) {
-                call.respond(
-                    HttpStatusCode.InternalServerError,
-                    ApiResponse(success = false, message = e.message, data = null, error = e.message)
-                )
-            }
+    post(Routes.SIGN_UP) {
+        try {
+            val request = call.receive<UserRegistrationRequest>()
+            val baseUrl = RequestUtils.requestBaseUrl(call)
+            val userResponse = authService.registerUser(request, baseUrl)
+            call.respond(
+                HttpStatusCode.Created,
+                ApiResponse(success = true, message = "User registered successfully", data = userResponse),
+            )
+        } catch (e: IllegalArgumentException) {
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ApiResponse(success = false, message = e.message, data = null, error = e.message),
+            )
+        } catch (e: Exception) {
+            call.respond(
+                HttpStatusCode.InternalServerError,
+                ApiResponse(success = false, message = e.message, data = null, error = e.message),
+            )
         }
+    }
 
-        post("/sign-in") {
-            try {
-                val credentials = call.receive<LoginCredentials>()
-                val token = authService.login(credentials)
-                call.respond(
-                    HttpStatusCode.OK,
-                    ApiResponse(success = true, message = "User logged in successfully", data = token)
-                )
-            } catch (e: IllegalArgumentException) {
-                call.respond(
-                    HttpStatusCode.BadRequest,
-                    ApiResponse(success = false, message = e.message, data = null, error = e.message)
-                )
-            } catch (e: Exception) {
-                call.respond(
-                    HttpStatusCode.InternalServerError,
-                    ApiResponse(success = false, message = e.message, data = null, error = e.message)
-                )
-            }
+    post(Routes.SIGN_IN) {
+        try {
+            val credentials = call.receive<LoginCredentials>()
+            val token = authService.login(credentials)
+            call.respond(
+                HttpStatusCode.OK,
+                ApiResponse(success = true, message = "User logged in successfully", data = token),
+            )
+        } catch (e: IllegalArgumentException) {
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ApiResponse(success = false, message = e.message, data = null, error = e.message),
+            )
+        } catch (e: Exception) {
+            call.respond(
+                HttpStatusCode.InternalServerError,
+                ApiResponse(success = false, message = e.message, data = null, error = e.message),
+            )
         }
+    }
 
-        post("/refresh") {
-            try {
-                val request = call.receive<RefreshTokenRequest>()
-                val token = authService.refreshToken(request)
-                call.respond(
-                    HttpStatusCode.OK,
-                    ApiResponse(success = true, message = "Token refreshed successfully", data = token)
-                )
-            } catch (e: IllegalArgumentException) {
-                call.respond(
-                    HttpStatusCode.BadRequest,
-                    ApiResponse(success = false, message = e.message, data = null, error = e.message)
-                )
-            } catch (e: Exception) {
-                call.respond(
-                    HttpStatusCode.InternalServerError,
-                    ApiResponse(success = false, message = e.message, data = null, error = e.message)
-                )
-            }
+    post(Routes.REFRESH) {
+        try {
+            val request = call.receive<RefreshTokenRequest>()
+            val token = authService.refreshToken(request)
+            call.respond(
+                HttpStatusCode.OK,
+                ApiResponse(success = true, message = "Token refreshed successfully", data = token),
+            )
+        } catch (e: IllegalArgumentException) {
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ApiResponse(success = false, message = e.message, data = null, error = e.message),
+            )
+        } catch (e: Exception) {
+            call.respond(
+                HttpStatusCode.InternalServerError,
+                ApiResponse(success = false, message = e.message, data = null, error = e.message),
+            )
         }
+    }
 
-        post("/forgot-password") {
-            try {
-                val request = call.receive<PasswordResetRequest>()
-                val response = authService.resetPassword(request.email)
-                call.respond(
-                    HttpStatusCode.OK,
-                    ApiResponse(success = true, message = "password reset email sent", data = response)
-                )
-            } catch (e: Exception) {
-                call.respond(
-                    HttpStatusCode.InternalServerError,
-                    ApiResponse(success = false, message = e.message, data = null, error = e.message)
-                )
-            }
+    post(Routes.FORGOT_PASSWORD) {
+        try {
+            val request = call.receive<PasswordResetRequest>()
+            val response = authService.resetPassword(request.email)
+            call.respond(
+                HttpStatusCode.OK,
+                ApiResponse(success = true, message = "password reset email sent", data = response),
+            )
+        } catch (e: Exception) {
+            call.respond(
+                HttpStatusCode.InternalServerError,
+                ApiResponse(success = false, message = e.message, data = null, error = e.message),
+            )
         }
+    }
 
-        authenticate("auth-jwt") {
-            post("/change-password") {
-                try {
-                    val principal = call.principal<JWTPrincipal>()
-                    val userId = principal?.getClaim("id", String::class)
+    get(Routes.VERIFY_EMAIL) {
+        try {
+            val token =
+                call.parameters["token"]
+                    ?: return@get call.respond(HttpStatusCode.BadRequest, "Token is required")
+
+            val verified = authService.verifyEmail(token)
+            if (verified) {
+                call.respond(HttpStatusCode.OK, mapOf("message" to "Email verified successfully"))
+            } else {
+                call.respond(HttpStatusCode.BadRequest, mapOf("message" to "Email verification failed"))
+            }
+        } catch (e: IllegalArgumentException) {
+            call.respond(HttpStatusCode.BadRequest, mapOf("message" to e.message))
+        } catch (e: Exception) {
+            call.respond(HttpStatusCode.InternalServerError, mapOf("message" to "An error occurred"))
+        }
+    }
+
+    authenticate("auth-jwt") {
+        post(Routes.CHANGE_PASSWORD) {
+            try {
+                val principal = call.principal<JWTPrincipal>()
+                val userId =
+                    principal?.getClaim("id", String::class)
                         ?: throw IllegalArgumentException("Invalid user ID")
 
-                    val request = call.receive<ChangePasswordRequest>()
-                    val user = authService.changePassword(UUID.fromString(userId), request)
+                val request = call.receive<ChangePasswordRequest>()
+                val user = authService.changePassword(UUID.fromString(userId), request)
 
-                    call.respond(
-                        HttpStatusCode.OK,
-                        ApiResponse(success = true, message = "Password changed successfully", data = user)
-                    )
-                } catch (e: IllegalArgumentException) {
-                    call.respond(
-                        HttpStatusCode.BadRequest,
-                        ApiResponse(success = false, message = e.message, data = null, error = e.message)
-                    )
-                } catch (e: Exception) {
-                    call.respond(
-                        HttpStatusCode.InternalServerError,
-                        ApiResponse(success = false, message = e.message, data = null, error = e.message)
-                    )
-                }
-            }
-            get("/verify-email") {
-                try {
-                    val token = call.parameters["token"]
-                        ?: return@get call.respond(HttpStatusCode.BadRequest, "Token is required")
-
-                    val verified = authService.verifyEmail(token)
-                    if (verified) {
-                        call.respond(HttpStatusCode.OK, mapOf("message" to "Email verified successfully"))
-                    } else {
-                        call.respond(HttpStatusCode.BadRequest, mapOf("message" to "Email verification failed"))
-                    }
-                } catch (e: IllegalArgumentException) {
-                    call.respond(HttpStatusCode.BadRequest, mapOf("message" to e.message))
-                } catch (e: Exception) {
-                    call.respond(HttpStatusCode.InternalServerError, mapOf("message" to "An error occurred"))
-                }
+                call.respond(
+                    HttpStatusCode.OK,
+                    ApiResponse(success = true, message = "Password changed successfully", data = user),
+                )
+            } catch (e: IllegalArgumentException) {
+                call.respond(
+                    HttpStatusCode.BadRequest,
+                    ApiResponse(success = false, message = e.message, data = null, error = e.message),
+                )
+            } catch (e: Exception) {
+                call.respond(
+                    HttpStatusCode.InternalServerError,
+                    ApiResponse(success = false, message = e.message, data = null, error = e.message),
+                )
             }
         }
     }

--- a/src/main/kotlin/com/example/api/AuthApi.kt
+++ b/src/main/kotlin/com/example/api/AuthApi.kt
@@ -145,6 +145,5 @@ fun Route.authRoutes(authService: AuthService) {
                 }
             }
         }
-
     }
 }

--- a/src/main/kotlin/com/example/database/entity/User.kt
+++ b/src/main/kotlin/com/example/database/entity/User.kt
@@ -23,7 +23,7 @@ object Users : UUIDTable() {
     val role: Column<UserRole> = enumeration("role", UserRole::class)
     val employerId: Column<String?> = varchar("employer_id", 50).nullable()
     val registrationNumber: Column<String?> = varchar("registration_number", 50).nullable()
-    val isActive: Column<Boolean> = bool("is_active").default(true)
+    val isActive: Column<Boolean> = bool("is_active").default(false)
     val profilePicture: Column<String?> = varchar("profile_picture", 255).nullable()
     val createdAt = datetime("created_at")
     val updatedAt = datetime("updated_at")

--- a/src/main/kotlin/com/example/di/EmailModule.kt
+++ b/src/main/kotlin/com/example/di/EmailModule.kt
@@ -8,5 +8,5 @@ import org.koin.dsl.module
 val emailModule = module {
     single { get<AppConfig>().smtp}
     single{EmailService(get())}
-    single{ EmailVerificationService(get(),get())}
+    single{ EmailVerificationService(get())}
 }

--- a/src/main/kotlin/com/example/services/auth/AuthService.kt
+++ b/src/main/kotlin/com/example/services/auth/AuthService.kt
@@ -16,61 +16,88 @@ class AuthService (
     private val emailVerificationService: EmailVerificationService
 ){
 
-    fun registerUser(request: UserRegistrationRequest): UserResponse = transaction {
-        // Check if email already exists
-        val existingUser = User.find { Users.email eq request.email }.firstOrNull()
-        if (existingUser != null) {
-            throw IllegalArgumentException("Email already registered")
-        }
+    fun registerUser(request: UserRegistrationRequest, baseUrl: String): UserResponse {
+        // Hold values produced inside the transaction so we can send email after commit
+        var createdUserResponse: UserResponse? = null
+        var emailToNotify: String? = null
+        var verificationToken: String? = null
 
-        validateRegistrationRequest(request)
-
-        val user = User.new {
-            email = request.email
-            passwordHash = BCrypt.hashpw(request.password, BCrypt.gensalt())
-            firstName = request.firstName
-            lastName = request.lastName
-            role = UserRole.valueOf(request.role)
-
-            // Set employerId based on role
-            employerId = when (role) {
-                UserRole.ADMIN, UserRole.LECTURER -> request.employerId ?: ""
-                else -> ""
+        transaction {
+            // Check if email already exists
+            val existingUser = User.find { Users.email eq request.email }.firstOrNull()
+            if (existingUser != null) {
+                throw IllegalArgumentException("Email already registered")
             }
 
-            // Set registrationNumber based on role
-            registrationNumber = when (role) {
-                UserRole.STUDENT -> request.registrationNumber ?: ""
-                else -> ""
+            validateRegistrationRequest(request)
+
+            val user = User.new {
+                email = request.email
+                passwordHash = BCrypt.hashpw(request.password, BCrypt.gensalt())
+                firstName = request.firstName
+                lastName = request.lastName
+                role = UserRole.valueOf(request.role)
+
+                // Set employerId based on role
+                employerId = when (role) {
+                    UserRole.ADMIN, UserRole.LECTURER -> request.employerId ?: ""
+                    else -> ""
+                }
+
+                // Set registrationNumber based on role
+                registrationNumber = when (role) {
+                    UserRole.STUDENT -> request.registrationNumber ?: ""
+                    else -> ""
+                }
+
+                isActive = true
+                createdAt = LocalDateTime.now()
+                updatedAt = LocalDateTime.now()
             }
 
-            isActive = true
-            createdAt = LocalDateTime.now()
-            updatedAt = LocalDateTime.now()
-        }
+            // Generate and persist verification token inside the transaction
+            val token = UUID.randomUUID().toString()
+            user.emailVerificationToken = token
+            user.emailVerificationTokenExpiry = LocalDateTime.now().plusHours(24)
+            // Exposed will persist these changes on transaction commit
 
-        emailVerificationService.sendVerificationEmail(user)
+            // Capture values to use after the transaction
+            emailToNotify = user.email
+            verificationToken = token
+            createdUserResponse = mapToUserResponse(user)
+        } // transaction committed here
 
-        return@transaction mapToUserResponse(user)
+        // Send email after transaction commits (avoid network IO inside transaction)
+        // These non-null assertions are safe because values were assigned inside the transaction above.
+        emailVerificationService.sendVerificationEmail(emailToNotify!!, verificationToken!!, baseUrl)
+
+        return createdUserResponse!!
     }
 
-    fun verifyEmail(token: String): Boolean = transaction {
-        val user = User.find {
-            Users.emailVerificationToken eq token
-        }.firstOrNull() ?: throw java.lang.IllegalArgumentException("Invalid verification token")
+    fun verifyEmail(token: String?): Boolean {
+        if (token.isNullOrBlank()) return false
 
-        if(user.emailVerificationTokenExpiry?.isBefore(LocalDateTime.now()) == true) {
-            throw java.lang.IllegalArgumentException("Verification token has expired")
+        return transaction {
+            val user = User.find { Users.emailVerificationToken eq token }.firstOrNull()
+                ?: return@transaction false
+
+            // Check expiry
+            val expiry = user.emailVerificationTokenExpiry
+            if (expiry == null || expiry.isBefore(LocalDateTime.now())) {
+                return@transaction false
+            }
+
+            user.apply {
+                this.emailVerified = true
+                this.isActive = true
+                this.emailVerificationToken = null
+                this.emailVerificationTokenExpiry = null
+                this.updatedAt = LocalDateTime.now()
+            }
+
+            // persist occurs on transaction commit
+            true
         }
-
-        user.apply {
-            emailVerified = true
-            emailVerificationToken = null
-            emailVerificationTokenExpiry = null
-            updatedAt = LocalDateTime.now()
-        }
-
-        return@transaction true
     }
 
     fun login(credentials: LoginCredentials): LoginTokenResponse = transaction {

--- a/src/main/kotlin/com/example/services/email/EmailService.kt
+++ b/src/main/kotlin/com/example/services/email/EmailService.kt
@@ -39,7 +39,7 @@ class EmailService(private val config: SmtpConfig) {
             }
             Transport.send(message)
         } catch (e: MessagingException) {
-            throw EmailServiceException("Failed to send email", e)
+            throw EmailServiceException("Failed to send email error ${e.message}", e)
         }
     }
 }

--- a/src/main/kotlin/com/example/services/email/EmailVerificationService.kt
+++ b/src/main/kotlin/com/example/services/email/EmailVerificationService.kt
@@ -3,7 +3,7 @@ package com.example.services.email
 import com.example.config.AppConfig
 import com.example.database.entity.User
 import java.time.LocalDateTime
-import java.util.UUID
+import java.util.*
 
 class EmailVerificationService(
     private val emailService: EmailService,
@@ -15,7 +15,7 @@ class EmailVerificationService(
 
     fun sendVerificationEmail(user: User) {
         val verificationToken = generateVerificationToken()
-        val verificationLink = "${appConfig.deployment.baseUrl}/api/auth/verify-email?token=$verificationToken"
+        val verificationLink = "${appConfig.deployment.baseUrl}api/auth/verify-email?token=$verificationToken"
         
         user.apply {
             emailVerificationToken = verificationToken

--- a/src/main/kotlin/com/example/services/email/EmailVerificationService.kt
+++ b/src/main/kotlin/com/example/services/email/EmailVerificationService.kt
@@ -1,47 +1,34 @@
 package com.example.services.email
 
-import com.example.config.AppConfig
-import com.example.database.entity.User
-import java.time.LocalDateTime
-import java.util.*
+import com.example.web.Routes
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 class EmailVerificationService(
-    private val emailService: EmailService,
-    private val appConfig: AppConfig
+    private val emailService: EmailService
 ) {
-    companion object {
-        private const val TOKEN_VALIDITY_HOURS = 24
-    }
-
-    fun sendVerificationEmail(user: User) {
-        val verificationToken = generateVerificationToken()
-        val verificationLink = "${appConfig.deployment.baseUrl}api/auth/verify-email?token=$verificationToken"
-        
-        user.apply {
-            emailVerificationToken = verificationToken
-            emailVerificationTokenExpiry = LocalDateTime.now().plusHours(TOKEN_VALIDITY_HOURS.toLong())
-        }
+    fun sendVerificationEmail(toEmail: String, verificationToken: String, baseUrl: String) {
+        val base = baseUrl.trimEnd('/')
+        val encodedToken = URLEncoder.encode(verificationToken, StandardCharsets.UTF_8.toString())
+        val verificationLink = "$base${Routes.VERIFY_EMAIL}?token=$encodedToken"
 
         val emailContent = """
             <html>
                 <body>
                     <h1>Welcome to Smart Attendance!</h1>
-                    <p>Dear ${user.firstName},</p>
-                    <p>Thank you for registering. Please verify your email address by clicking the link below:</p>
+                    <p>Dear user,</p>
+                    <p>Please verify your email address by clicking the link below:</p>
                     <p><a href="$verificationLink">Verify Email Address</a></p>
                     <p>This link will expire in 24 hours.</p>
-                    <p>If you didn't create an account, please ignore this email.</p>
                 </body>
             </html>
         """.trimIndent()
 
         emailService.sendEmail(
-            to = user.email,
+            to = toEmail,
             subject = "Verify Your Email Address",
             content = emailContent,
             isHtml = true
         )
     }
-
-    private fun generateVerificationToken(): String = UUID.randomUUID().toString()
 }

--- a/src/main/kotlin/com/example/web/RequestUtils.kt
+++ b/src/main/kotlin/com/example/web/RequestUtils.kt
@@ -1,0 +1,43 @@
+package com.example.web
+
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.header
+
+object RequestUtils {
+    /**
+     * Determine the public base URL from an incoming request.
+     * Prefer X-Forwarded-Proto and X-Forwarded-Host (ngrok sets these) then fall back to Host + local scheme.
+     * Returns a string like "https://4881ee814b07.ngrok-free.app" (no trailing slash).
+     */
+    fun requestBaseUrl(call: ApplicationCall): String {
+        val forwardedProto = call.request.header("X-Forwarded-Proto")?.trim()
+        val forwardedHost = call.request.header("X-Forwarded-Host")?.trim()
+        val forwardedPort = call.request.header("X-Forwarded-Port")?.trim()
+        val hostHeader = call.request.header("Host")?.trim()
+
+        val scheme = forwardedProto ?: call.request.local.scheme
+        val rawHost = when {
+            forwardedHost != null -> forwardedHost
+            hostHeader != null -> hostHeader
+            else -> {
+                val localHost = call.request.local.localHost
+                val localPort = call.request.local.localPort
+                if (isDefaultPortForScheme(localPort, scheme)) localHost else "$localHost:$localPort"
+            }
+        }
+
+        // If forwardedPort is present and host does not already contain a port, append it when non-default.
+        val host = if (forwardedPort != null && !rawHost.contains(":")) {
+            val portInt = forwardedPort.toIntOrNull()
+            if (portInt != null && !isDefaultPortForScheme(portInt, scheme)) "$rawHost:$portInt" else rawHost
+        } else {
+            rawHost
+        }
+
+        return "$scheme://${host.trimEnd('/')}"
+    }
+
+    private fun isDefaultPortForScheme(port: Int, scheme: String): Boolean =
+        (scheme.equals("http", ignoreCase = true) && port == 80) ||
+            (scheme.equals("https", ignoreCase = true) && port == 443)
+}

--- a/src/main/kotlin/com/example/web/Routes.kt
+++ b/src/main/kotlin/com/example/web/Routes.kt
@@ -1,0 +1,12 @@
+package com.example.web
+
+object Routes {
+    const val AUTH_PREFIX = "/auth"
+
+    const val SIGN_UP = "$AUTH_PREFIX/sign-up"
+    const val SIGN_IN = "$AUTH_PREFIX/sign-in"
+    const val VERIFY_EMAIL = "$AUTH_PREFIX/verify-email"
+    const val REFRESH = "$AUTH_PREFIX/refresh"
+    const val FORGOT_PASSWORD = "$AUTH_PREFIX/forgot_password"
+    const val CHANGE_PASSWORD = "$AUTH_PREFIX/change_password"
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,29 +1,29 @@
 ktor:
   deployment:
-    host: "$PROD_HOST:0.0.0.0"
-    port: "$PROD_PORT:8080"
-    baseUrl: "$BASE_URL:http://localhost:8080"
+    host: "$PROD_HOST"
+    port: "$PROD_PORT"
+    baseUrl: "$BASE_URL"
 
   security:
     jwt:
-      secret: "$JWT_SECRETE:devSecreteKey"
+      secret: "$JWT_SECRETE"
       issuer: ""
       audience: ""
       realm: ""
 
   database:
-    jdbcUrl: "$DB_DRIVER_CLASS_NAME:org.postgresql.Driver"
-    host: "$DB_HOST:localhost"
-    port: "$DATABASE_PORT:5432"
-    username: "$DB_USERNAME:postgres"
-    password: "$DB_PASSWORD:root"
-    databaseName: "$DB_NAME:smartattendance"
+    jdbcUrl: "$DB_DRIVER_CLASS_NAME"
+    host: "$DB_HOST"
+    port: "$DATABASE_PORT"
+    username: "$DB_USERNAME"
+    password: "$DB_PASSWORD"
+    databaseName: "$DB_NAME"
 
   smtp:
-    host: "$SMTP_HOST:smtp.gmail.com"
-    port: "$SMTP_PORT:587"
-    username: "$SMTP_USERNAME:your-email@gmail.com"
-    password: "$SMTP_PASSWORD:your-app-specific-password"
-    fromEmail: "$SMTP_FROM_EMAIL:your-email@gmail.com"
-    ssl: "$SMTP_SSL:true"
-    starttls: "$SMTP_STARTTLS:true"
+    host: "$SMTP_HOST"
+    port: "$SMTP_PORT"
+    username: "$SMTP_USERNAME"
+    password: "$SMTP_PASSWORD"
+    fromEmail: "$SMTP_FROM_EMAIL"
+    ssl: "$SMTP_SSL"
+    starttls: "$SMTP_STARTTLS"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,7 +6,7 @@ ktor:
 
   security:
     jwt:
-      secret: "$JWT_SECRETE"
+      secret: "$JWT_SECRET"
       issuer: ""
       audience: ""
       realm: ""

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -2133,15 +2133,20 @@ components:
     StudentSignUpRequest:
       type: object
       required:
-        - name
         - email
+        - firstName
+        - LastName
         - password
         - role
-        - regNo
+        - employerId
+        - registrationNumber
       properties:
-        name:
+        firstName:
           type: string
-          example: "John Student"
+          example: "John"
+        lastName:
+          type: string
+          example: "okello"
         email:
           type: string
           format: email
@@ -2154,16 +2159,12 @@ components:
           type: string
           enum: [ STUDENT ]
           example: "STUDENT"
-        regNo:
+        registrationNumber:
           type: string
           example: "STU12345"
-        department:
+        employerId:
           type: string
-          example: "Computer Science"
-          nullable: true
-        yearOfStudy:
-          type: integer
-          example: 2
+          example:
           nullable: true
 
     LecturerSignUpRequest:

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -38,7 +38,7 @@ paths:
   #
   # Authentication Routes
   #
-  /auth/signup:
+  /auth/sign-up:
     post:
       tags:
         - Authentication
@@ -73,7 +73,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /auth/login:
+  /auth/sign-in:
     post:
       tags:
         - Authentication
@@ -142,6 +142,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/verify:
+    get:
+      tags:
+        - verify email
+      summary: Get a verification token sent to user email address for verification
+      description: Get email verification token from server
+      parameters:
+      responses:
+        "200":
+          description:
+          content:
+
 
   #
   # User Routes


### PR DESCRIPTION
##  PR: Dynamic verification URLs, token persistence, route centralization

Summary
- Compute public base URL from incoming requests so verification links use the live host (works with ngrok).
- Persist email verification tokens inside the DB transaction and send the email after commit.
- Centralize auth route paths and update email sender and routes to use the same constants to avoid path drift.

What changed (concise)
- RequestUtils.requestBaseUrl: derive public base URL from X-Forwarded-* or Host headers.
- Routes constants: central AUTH route strings (SIGN_UP, VERIFY_EMAIL).
- AuthService.registerUser: generate & persist token in-transaction; return and send email after commit; now accepts runtime baseUrl.
- EmailVerificationService: accepts baseUrl, encodes token, builds verification link from Routes constants.
- Dev: ngrok helper to query local API for public URL (dev-only).
- .env.dev template added and local env files ignored in .gitignore.

Why
- Prevent broken/stale verification links when ngrok rotates hostnames.
- Avoid performing network I/O inside DB transactions and avoid sending emails before DB commit.
- Eliminate drift between registered routes and generated links.

Testing (manual)
1. Start ngrok and note public URL (e.g. https://moose-relax-certainly.ngrok-free.app).
2. Start app with DOTENV_FILENAME or ensure required env vars present.
3. POST to {ngrok}/auth/sign-up to create a user.
4. Confirm email contains a link using the same ngrok host and path /auth/verify-email.
5. Click link and confirm server handles GET /auth/verify-email?token=... (no 404) and token verification succeeds.

## screenshots
<img width="521" height="260" alt="image" src="https://github.com/user-attachments/assets/a694e661-694a-4ede-8432-6b9791561732" />
<img width="317" height="131" alt="image" src="https://github.com/user-attachments/assets/673264c7-84a8-43f7-9972-3918a2fd363a" />

